### PR TITLE
refactor: Allow talon to be overridden to allow beta use

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ showing up.
 
 ## Can I use Talon Beta?
 
-The Talon Beta URLs and tarballs are private and also change across each release.
-If you want to run the Talon Beta, download a beta tarball from the URLs hosted in
-the `#beta` slack channel, then use the `steam-run` approach mentioned above.
+Yes, but please remember the Talon Beta URLs are meant to be kept private. You can manually override the talon-nix
+flake, but it is important that you DO NOT include the hardcoded URLs in a public repository. You should keep the URL
+private by importing a secrets repo into your config flake, and have the beta URL inside of the secret flake. However,
+this will expose the URL in the nix store, so if you are using a shared system, you will need to use some other
+approach.
+
+The following is an example of how this might look:
+
+```nix
+    nixpkgs = {
+        overlays = [
+        inputs.talon-nix.overlays.default
+        (final: prev: {
+            talon-unwrapped = prev.talon-unwrapped.overrideAttrs (oldAttrs: {
+            version = "0.4.0-359-g5c35";
+            src = builtins.fetchurl {
+                url = inputs.nix-secrets.talon-beta-url;
+                sha256 = "sha256:07ia3cnr1ayckcffr3zw6l9j3fz8ywxcxjw68ba647994s2n2zfa";
+            };
+            });
+        })
+        ];
+    };
+```
+

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693660503,
-        "narHash": "sha256-B/g2V4v6gjirFmy+I5mwB2bCYc0l3j5scVfwgl6WOl8=",
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "bd5bdbb52350e145c526108f4ef192eb8e554fa0",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1718530797,
+        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
         "type": "github"
       },
       "original": {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,8 +1,12 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   cfg = config.programs.talon;
-
 in
 {
   options.programs.talon = {

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,5 @@
 final: prev: {
-  talon = final.callPackage ./talon.nix { };
+  talon-unwrapped =
+    if prev ? talon-unwrapped then prev.talon-unwrapped else prev.callPackage ./talon-unwrapped.nix { };
+  talon = prev.callPackage ./talon.nix { pkgs = final; };
 }

--- a/talon-unwrapped.nix
+++ b/talon-unwrapped.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+}:
+let
+  inherit (lib.importJSON ./src.json) version sha256;
+
+  meta = {
+    homepage = "https://talonvoice.com/";
+    description = "Voice coding application unwrapped";
+    license = lib.licenses.unfree;
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+in
+stdenv.mkDerivation {
+  pname = "talon";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://talonvoice.com/dl/latest/talon-linux.tar.xz";
+    inherit sha256;
+  };
+
+  preferLocalBuild = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt/talon
+    cp -a * $out/opt/talon/
+
+    mkdir -p "$out/etc/udev/rules.d"
+    cp 10-talon.rules $out/etc/udev/rules.d
+    # Remove udev compatibility hack using plugdev for older debian/ubuntu
+    # This breaks NixOS usage of these rules (see https://github.com/NixOS/nixpkgs/issues/76482)
+    substituteInPlace $out/etc/udev/rules.d/10-talon.rules --replace 'GROUP="plugdev",' ""
+
+    mkdir -p $out/share/applications
+    cat << EOF > $out/share/applications/talon.desktop
+      [Desktop Entry]
+      Categories=Utility;
+      Exec=talon
+      Name=Talon
+      Terminal=false
+      Type=Application
+    EOF
+
+    mkdir -p $out/bin
+    ln -s $out/opt/talon/talon $out/bin/talon
+    ln -s $out/opt/talon/lib $out
+
+    runHook postInstall
+  '';
+
+  inherit meta;
+}

--- a/talon.nix
+++ b/talon.nix
@@ -1,65 +1,16 @@
-{ stdenv
-, buildFHSEnv
-, lib
-, fetchurl
+{
+  buildFHSEnv,
+  lib,
+  pkgs,
 }:
-
 let
-  inherit (lib.importJSON ./src.json) version sha256;
-
   meta = {
     homepage = "https://talonvoice.com/";
-    description = "Voice coding application";
+    description = "Voice coding application. FHS wrapped.";
     license = lib.licenses.unfree;
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-
-  talon = stdenv.mkDerivation {
-    pname = "talon";
-    inherit version;
-
-    src = fetchurl {
-      url = "https://talonvoice.com/dl/latest/talon-linux.tar.xz";
-      inherit sha256;
-    };
-
-    preferLocalBuild = true;
-    dontBuild = true;
-    dontConfigure = true;
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out/opt/talon
-      cp -a * $out/opt/talon/
-
-      mkdir -p "$out/etc/udev/rules.d"
-      cp 10-talon.rules $out/etc/udev/rules.d
-      # Remove udev compatibility hack using plugdev for older debian/ubuntu
-      # This breaks NixOS usage of these rules (see https://github.com/NixOS/nixpkgs/issues/76482)
-      substituteInPlace $out/etc/udev/rules.d/10-talon.rules --replace 'GROUP="plugdev",' ""
-
-      mkdir -p $out/share/applications
-      cat << EOF > $out/share/applications/talon.desktop
-        [Desktop Entry]
-        Categories=Utility;
-        Exec=talon
-        Name=Talon
-        Terminal=false
-        Type=Application
-      EOF
-
-      mkdir -p $out/bin
-      ln -s $out/opt/talon/talon $out/bin/talon
-      ln -s $out/opt/talon/lib $out
-
-      runHook postInstall
-    '';
-
-    inherit meta;
-  };
-
 in
 buildFHSEnv {
   name = "talon";
@@ -69,65 +20,68 @@ buildFHSEnv {
     export LC_NUMERIC=C
     export QT_PLUGIN_PATH="/lib/plugins"
 
-    export LD_LIBRARY_PATH=${lib.concatStringsSep ":" [
-      "/opt/talon/resources/python/lib/python3.11/site-packages/numpy.libs"
-      "/opt/talon/resources/python/lib"
-    ]}
+    export LD_LIBRARY_PATH=${
+      lib.concatStringsSep ":" [
+        "/opt/talon/resources/python/lib/python3.11/site-packages/numpy.libs"
+        "/opt/talon/resources/python/lib"
+      ]
+    }
   '';
 
   extraInstallCommands = ''
-    ln -s ${talon}/share $out/share
-    ln -s ${talon}/etc $out/etc
+    ln -s ${pkgs.talon-unwrapped}/share $out/share
+    ln -s ${pkgs.talon-unwrapped}/etc $out/etc
   '';
 
-  runScript = "${talon}/bin/talon";
+  runScript = "${pkgs.talon-unwrapped}/bin/talon";
 
-  targetPkgs = pkgs: with pkgs; [
-    stdenv.cc.cc
-    stdenv.cc.libc
-    dbus
-    fontconfig
-    freetype
-    glib
-    libGL
-    libxkbcommon
-    sqlite
-    zlib
-    libpulseaudio
-    udev
-    xorg.libX11
-    xorg.libSM
-    xorg.libXcursor
-    xorg.libICE
-    xorg.libXrender
-    xorg.libxcb
-    xorg.libXext
-    xorg.libXcomposite
-    xorg.libXrandr
-    xorg.libXi
-    bzip2
-    ncurses5
-    libuuid
-    gtk3-x11
-    gdk-pixbuf
-    cairo
-    libdrm
-    gnome2.pango
-    gdbm
-    atk
-    wayland
-    wayland-protocols
-    wlroots
-    xwayland
-    libinput
-    libxml2
-    speechd
-    gfortran
-    # gfortran.cc default output contains static libraries compiled without -fPIC
-    # we want libgfortran.so instead (see: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/science/math/giac/default.nix)
-    (lib.getLib gfortran.cc)
-    talon
-  ];
+  targetPkgs =
+    pkgs: with pkgs; [
+      stdenv.cc.cc
+      stdenv.cc.libc
+      dbus
+      fontconfig
+      freetype
+      glib
+      libGL
+      libxkbcommon
+      sqlite
+      zlib
+      libpulseaudio
+      udev
+      xorg.libX11
+      xorg.libSM
+      xorg.libXcursor
+      xorg.libICE
+      xorg.libXrender
+      xorg.libxcb
+      xorg.libXext
+      xorg.libXcomposite
+      xorg.libXrandr
+      xorg.libXi
+      bzip2
+      ncurses5
+      libuuid
+      gtk3-x11
+      gdk-pixbuf
+      cairo
+      libdrm
+      gnome2.pango
+      gdbm
+      atk
+      wayland
+      wayland-protocols
+      wlroots
+      xwayland
+      libinput
+      libxml2
+      speechd
+      gfortran
+      # gfortran.cc default output contains static libraries compiled without -fPIC
+      # we want libgfortran.so instead (see: https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/science/math/giac/default.nix)
+      (lib.getLib gfortran.cc)
+      talon-unwrapped
+    ];
 
   inherit meta;
 }

--- a/talon.nix
+++ b/talon.nix
@@ -66,7 +66,7 @@ buildFHSEnv {
       gdk-pixbuf
       cairo
       libdrm
-      gnome.pango
+      pango
       gdbm
       atk
       wayland

--- a/talon.nix
+++ b/talon.nix
@@ -66,7 +66,7 @@ buildFHSEnv {
       gdk-pixbuf
       cairo
       libdrm
-      gnome2.pango
+      gnome.pango
       gdbm
       atk
       wayland


### PR DESCRIPTION
Talon has a beta version that uses non-public URLs, so can't be published directly in the flake. Otherwise, the beta versions do work fine in nix. This PR refactors the way the talon packages are built to allow the unwrapped version of talon to be overridden with a beta url, along the lines of this:

```
      (final: prev: {
        talon-unwrapped = prev.talon-unwrapped.overrideAttrs (oldAttrs: {
          version = "0.4.0-359-g5c35";
          src = builtins.fetchurl {
            url = inputs.nix-secrets.talon-beta-url;
            sha256 = "sha256:07ia3cnr1ayckcffr3zw6l9j3fz8ywxcxjw68ba647994s2n2zfa";
          };
        });
```

Most Talon nix users I've spoken to are on beta, so I wanted to make this available to everyone.

I also stopped hardcoding x86_64-linux everywhere because I plan to start testing this on aarch64 darwin as well, but will be a follow up.

Formatting is done using nixfmt-rfc-style so also a few changes